### PR TITLE
fix dead import

### DIFF
--- a/source/sass/style.scss
+++ b/source/sass/style.scss
@@ -1,7 +1,6 @@
 @import "logo";
 @import "header";
 @import "main";
-@import "main-nav";
 @import "footer";
 @import "catalog-main";
 @import "instruction";


### PR DESCRIPTION
на данный момент academy/master содержит scss файл (style.scss) с импортом несуществующего фала main-nav.  ранее эта проблема появлялась, в каких-то ветках фиксилось. но вылезает опять.
пора положить конец.
![Screenshot_8](https://user-images.githubusercontent.com/34519720/62822324-4dffc700-bb8a-11e9-8a41-8174433865ca.png)
